### PR TITLE
Fix UBTU-20-010072 oval checks for accounts-pam

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/oval/shared.xml
@@ -12,7 +12,7 @@
         comment="Check expected value for pam_faillock.so audit parameter">
             <criteria operator="AND"
             comment="Check expected pam_faillock.so audit parameter in pam files">
-                {{% if 'ubuntu' not in product %}}
+                {{% if 'ubuntu2004' not in product %}}
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_system_auth"
                 comment="Check the audit parameter in auth section of system-auth file"/>
@@ -24,7 +24,7 @@
                 test_ref="test_pam_faillock_audit_parameter_common_auth"
                 comment="Check the audit parmaeter in auth section of common-auth file"/>
                 {{% endif %}}
-                {{% if 'ubuntu' not in product %}}
+                {{% if 'ubuntu2004' not in product %}}
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_no_faillock_conf"
                 comment="Ensure /etc/security/faillock.conf is not used together with pam files"/>
@@ -32,7 +32,7 @@
             </criteria>
             <criteria operator="AND"
             comment="Check expected pam_faillock.so audit parameter in faillock.conf">
-                {{% if 'ubuntu' not in product %}}
+                {{% if 'ubuntu2004' not in product %}}
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_no_pamd_system"
                 comment="Check the audit parameter is not present system-auth file"/>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/oval/shared.xml
@@ -12,24 +12,35 @@
         comment="Check expected value for pam_faillock.so audit parameter">
             <criteria operator="AND"
             comment="Check expected pam_faillock.so audit parameter in pam files">
+                {{% if 'ubuntu' not in product %}}
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_system_auth"
                 comment="Check the audit parameter in auth section of system-auth file"/>
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_password_auth"
                 comment="Check the audit parameter in auth section of password-auth file"/>
+                {{% else %}}
+                <criterion
+                test_ref="test_pam_faillock_audit_parameter_common_auth"
+                comment="Check the audit parmaeter in auth section of common-auth file"/>
+                {{% endif %}}
+                {{% if 'ubuntu' not in product %}}
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_no_faillock_conf"
                 comment="Ensure /etc/security/faillock.conf is not used together with pam files"/>
+                {{% endif %}}
             </criteria>
             <criteria operator="AND"
             comment="Check expected pam_faillock.so audit parameter in faillock.conf">
+                {{% if 'ubuntu' not in product %}}
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_no_pamd_system"
                 comment="Check the audit parameter is not present system-auth file"/>
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_no_pamd_password"
                 comment="Check the audit parameter is not present password-auth file"/>
+                {{% else %}}
+                {{% endif %}}
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_faillock_conf"
                 comment="Ensure the audit parameter is present in /etc/security/faillock.conf"/>
@@ -42,6 +53,10 @@
         <value>^[\s]*auth[\s]+(?:required|requisite)[\s]+pam_faillock.so[^\n#]preauth[^\n#]*audit</value>
     </constant_variable>
 
+    <constant_variable id="var_pam_faillock_audit_parameter_authsucc_regex" version="1" datatype="string" comment="regex to identify the authsucc audit parameter in pam files">
+        <value>[\s]*auth[\s]+(?:sufficient)[\s]+pam_faillock.so[^\n#]authsucc</value>
+    </constant_variable>
+
     <ind:textfilecontent54_object id="obj_all_pam_faillock_audit_parameter_system_auth"
     comment="Get the pam_faillock.so preauth audit parameter from system-auth file" version="1">
         <ind:filepath >/etc/pam.d/system-auth</ind:filepath>
@@ -51,10 +66,17 @@
     </ind:textfilecontent54_object>
 
     <ind:textfilecontent54_object id="obj_all_pam_faillock_audit_parameter_password_auth"
-    comment="Get the pam_faillock.so preauth audit parameter from system-auth file" version="1">
+    comment="Get the pam_faillock.so preauth audit parameter from password-auth file" version="1">
         <ind:filepath >/etc/pam.d/password-auth</ind:filepath>
         <ind:pattern operation="pattern match"
         var_ref="var_pam_faillock_audit_parameter_regex" />
+        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <ind:textfilecontent54_object id="obj_all_pam_faillock_audit_parameter_common_auth" comment="Get the pam_faillock.so authsucc audit parameter from common-auth file" version="1">
+        <ind:filepath >/etc/pam.d/common-auth</ind:filepath>
+        <ind:pattern operation="pattern match"
+        var_ref="var_pam_faillock_audit_parameter_authsucc_regex" />
         <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
     </ind:textfilecontent54_object>
 
@@ -71,6 +93,19 @@
     comment="Check the absence of audit parameter in system-auth">
         <ind:object
         object_ref="obj_all_pam_faillock_audit_parameter_system_auth"/>
+    </ind:textfilecontent54_test>
+
+    <!-- Check the pam_faillock.so audit parameter in common-auth -->
+    <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" version="1"
+    id="test_pam_faillock_audit_parameter_common_auth"
+    comment="Check the presence of audit parameter in common-auth">
+        <ind:object
+        object_ref="obj_all_pam_faillock_audit_parameter_common_auth"/>
+    </ind:textfilecontent54_test>
+
+    <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1" id="test_pam_faillock_audit_parameter_no_pamd_common" comment="Check the absence of audit parameter in common-auth">
+        <ind:object
+        object_ref="obj_all_pam_faillock_audit_parameter_common_auth"/> 
     </ind:textfilecontent54_test>
 
     <!-- Check the pam_faillock.so audit parameter in password-auth -->

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/ubuntu.xml
@@ -10,13 +10,17 @@
             comment="pam_unix.so appears only once in auth section of common-auth"/>
         <criterion test_ref="test_accounts_passwords_pam_faillock_deny_common_pam_faillock_auth"
             comment="pam_faillock.so is properly defined in auth section of common-auth"/>
+        {{% if 'ubuntu2004' not in product %}}
         <criterion test_ref="test_accounts_passwords_pam_faillock_deny_common_pam_faillock_account"
             comment="pam_faillock.so is properly defined in common-account"/>
+        {{% endif %}}
       </criteria>
       <criteria operator="AND"
           comment="Check expected pam_faillock.so deny parameter in faillock.conf">
+        {{% if 'ubuntu2004' not in product %}}
         <criterion test_ref="test_accounts_passwords_pam_faillock_deny_parameter_no_pamd_common"
             comment="Check the deny parameter is not present in common-auth file"/>
+        {{% endif %}}
         <criterion  test_ref="test_accounts_passwords_pam_faillock_deny_parameter_faillock_conf"
             comment="Ensure the deny parameter is present in /etc/security/faillock.conf"/>
         </criteria>
@@ -31,10 +35,32 @@
     <value>^\s*auth.*pam_unix\.so</value>
   </constant_variable>
 
-  <constant_variable id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_regex"
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_preauth_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
-    <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*\n^\s*auth.*pam_unix\.so.*\n^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail.*\n^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc.*$</value>
+    <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_unix_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth.*pam_unix\.so.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authfail_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authsucc_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc.*$</value>
   </constant_variable>
 
   <constant_variable id="var_accounts_passwords_pam_faillock_deny_pam_faillock_account_regex"
@@ -86,7 +112,13 @@
         comment="Check common definition of pam_faillock.so in auth section of common-auth">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_preauth_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_unix_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authfail_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authsucc_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/ubuntu.xml
@@ -10,8 +10,10 @@
             comment="pam_unix.so appears only once in auth section of common-auth"/>
         <criterion test_ref="test_accounts_passwords_pam_faillock_interval_common_pam_faillock_auth"
              comment="pam_faillock.so is properly defined in auth section of common-auth"/>
+        {{% if 'ubuntu2004' not in product %}}
         <criterion test_ref="test_accounts_passwords_pam_faillock_interval_common_pam_faillock_account"
              comment="pam_faillock.so is properly defined in common-account"/>
+        {{% endif %}}
       </criteria>
       <criteria operator="AND"
                 comment="Check expected value for pam_faillock.so fail_interval parameter">
@@ -31,10 +33,32 @@
     <value>^\s*auth.*pam_unix\.so</value>
   </constant_variable>
 
-  <constant_variable id="var_accounts_passwords_pam_faillock_interval_pam_faillock_auth_regex"
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_preauth_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
-    <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*\n^\s*auth.*pam_unix\.so.*\n^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail.*\n^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc.*$</value>
+    <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_unix_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth.*pam_unix\.so.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authfail_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authsucc_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc.*$</value>
   </constant_variable>
 
   <constant_variable id="var_accounts_passwords_pam_faillock_interval_pam_faillock_account_regex"
@@ -86,7 +110,13 @@
         comment="Check common definition of pam_faillock.so in auth section of common-auth">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_interval_pam_faillock_auth_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_preauth_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_unix_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authfail_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authsucc_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/ubuntu.xml
@@ -34,28 +34,21 @@
   </constant_variable>
 
   <constant_variable
-  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_preauth_regex"
+  id="var_accounts_passwords_pam_faillock_interval_pam_faillock_auth_preauth_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
     <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*$</value>
   </constant_variable>
 
   <constant_variable
-  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_unix_regex"
-                datatype="string" version="1"
-                comment="regex to identify pam_faillock.so entries in auth section of pam files">
-    <value>^\s*auth.*pam_unix\.so.*$</value>
-  </constant_variable>
-
-  <constant_variable
-  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authfail_regex"
+  id="var_accounts_passwords_pam_faillock_interval_pam_faillock_auth_authfail_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
     <value>^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail.*$</value>
   </constant_variable>
 
   <constant_variable
-  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authsucc_regex"
+  id="var_accounts_passwords_pam_faillock_interval_pam_faillock_auth_authsucc_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
     <value>^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc.*$</value>
@@ -110,13 +103,13 @@
         comment="Check common definition of pam_faillock.so in auth section of common-auth">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_preauth_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_interval_pam_faillock_auth_preauth_regex"/>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_unix_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_interval_pam_unix_regex"/>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authfail_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_interval_pam_faillock_auth_authfail_regex"/>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authsucc_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_interval_pam_faillock_auth_authsucc_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -158,7 +151,7 @@
   <ind:textfilecontent54_object version="1"
         id="object_accounts_passwords_pam_faillock_interval_parameter_pamd_common"
         comment="Get the pam_faillock.so fail_interval parameter from common-auth file">
-    <ind:filepath>/etc/pam.d/comon-auth</ind:filepath>
+    <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
                  var_ref="var_accounts_passwords_pam_faillock_interval_pam_faillock_fail_interval_parameter_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/shared.xml
@@ -10,7 +10,7 @@
             that if faillock.conf is available, authselect tool only manage parameters on it -->
         <criteria operator="OR"
         comment="Check expected value for pam_faillock.so silent parameter">
-            {{% if 'ubuntu' not in product %}}
+            {{% if 'ubuntu2004' not in product %}}
             <criteria operator="AND"
             comment="Check expected pam_faillock.so silent parameter in pam files">
                 <criterion
@@ -23,7 +23,7 @@
             {{% endif %}}
             <criteria operator="AND"
             comment="Check expected pam_faillock.so silent parameter in faillock.conf">
-                {{% if 'ubuntu' not in product %}}
+                {{% if 'ubuntu2004' not in product %}}
                 <criterion
                 test_ref="test_pam_faillock_silent_parameter_no_pamd_system"
                 comment="Check the silent parameter is not present system-auth file"/>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/shared.xml
@@ -10,6 +10,7 @@
             that if faillock.conf is available, authselect tool only manage parameters on it -->
         <criteria operator="OR"
         comment="Check expected value for pam_faillock.so silent parameter">
+            {{% if 'ubuntu' not in product %}}
             <criteria operator="AND"
             comment="Check expected pam_faillock.so silent parameter in pam files">
                 <criterion
@@ -19,14 +20,17 @@
                 test_ref="test_pam_faillock_silent_parameter_password_auth"
                 comment="Check the silent parameter in auth section of password-auth file"/>
             </criteria>
+            {{% endif %}}
             <criteria operator="AND"
             comment="Check expected pam_faillock.so silent parameter in faillock.conf">
+                {{% if 'ubuntu' not in product %}}
                 <criterion
                 test_ref="test_pam_faillock_silent_parameter_no_pamd_system"
                 comment="Check the silent parameter is not present system-auth file"/>
                 <criterion
                 test_ref="test_pam_faillock_silent_parameter_no_pamd_password"
                 comment="Check the silent parameter is not present password-auth file"/>
+                {{% endif %}}
                 <criterion
                 test_ref="test_pam_faillock_silent_parameter_faillock_conf"
                 comment="Ensure the silent parameter is present in /etc/security/faillock.conf"/>
@@ -48,7 +52,7 @@
     </ind:textfilecontent54_object>
 
     <ind:textfilecontent54_object id="obj_all_pam_faillock_silent_parameter_password_auth"
-    comment="Get the pam_faillock.so preauth silent parameter from system-auth file" version="1">
+    comment="Get the pam_faillock.so preauth silent parameter from password-auth file" version="1">
         <ind:filepath >/etc/pam.d/password-auth</ind:filepath>
         <ind:pattern operation="pattern match"
         var_ref="var_pam_faillock_silent_parameter_regex" />

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/ubuntu.xml
@@ -10,13 +10,17 @@
             comment="pam_unix.so appears only once in auth section of common-auth"/>
         <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_common_pam_faillock_auth"
             comment="pam_faillock.so is properly defined in auth section of common-auth"/>
+        {{% if 'ubuntu2004' not in product %}}
         <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_common_pam_faillock_account"
             comment="pam_faillock.so is properly defined in common-account"/>
+        {{% endif %}}
       </criteria>
       <criteria operator="OR"
                 comment="Check expected value for pam_faillock.so unlock_time parameter">
+        {{% if 'ubuntu2004' in product %}}
         <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_parameter_no_pamd_common"
             comment="Check the unlock_time parameter is not present common-auth file"/>
+        {{% endif %}}
         <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_parameter_faillock_conf"
             comment="Ensure the unlock_time parameter is present in /etc/security/faillock.conf"/>
       </criteria>
@@ -31,10 +35,25 @@
     <value>^\s*auth.*pam_unix\.so</value>
   </constant_variable>
 
-  <constant_variable id="var_accounts_passwords_pam_faillock_unlock_time_pam_faillock_auth_regex"
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_unlock_pam_faillock_auth_authfail_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
-    <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*\n^\s*auth.*pam_unix\.so.*\n^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail.*\n^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc.*$</value>
+    <value>^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_unlock_pam_faillock_auth_authsucc_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_unlock_pam_faillock_auth_preauth_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*$</value>
   </constant_variable>
 
   <constant_variable id="var_accounts_passwords_pam_faillock_unlock_time_pam_faillock_account_regex"
@@ -86,7 +105,13 @@
         comment="Check common definition of pam_faillock.so in auth section of common-auth">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_unlock_time_pam_faillock_auth_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_unlock_pam_faillock_auth_authfail_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_unlock_pam_faillock_auth_authsucc_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_unlock_pam_faillock_auth_preauth_regex"/>
+    <ind:pattern opeartion="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_unlock_time_pam_unix_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1006,19 +1006,26 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       changed_when: false
       register: result_pam_faillock_is_enabled
 
-    {{% if 'ubuntu' not in product %}}
     - name: {{{ rule_title }}} - Enable pam_faillock.so preauth editing PAM files
       ansible.builtin.lineinfile:
         path: '{{ item }}'
         line: auth        required      pam_faillock.so preauth
+        {{% if 'ubuntu' in product %}}
+        insertbefore: ^auth.*.*pam_unix\.so.*
+        {{% else %}}
         insertbefore: ^auth.*sufficient.*pam_unix\.so.*
+        {{% endif %}}
         state: present
       loop:
+        {{% if 'ubuntu' in product %}}
+        - /etc/pam.d/common-auth
+        {{% else %}}
         - /etc/pam.d/system-auth
         - /etc/pam.d/password-auth
+        {{% endif %}}
       when:
         - result_pam_faillock_is_enabled.found == 0
-    {{% else %}}
+    {{% if 'ubuntu' not in product %}}
     - name: {{{ rule_title }}} - Enable pam_faillock.so authsucc editing PAM files
       ansible.builtin.lineinfile:
         path: /etc/pam.d/common-auth

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -985,6 +985,14 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 
 {{{ ansible_check_authselect_presence() }}}
 
+- name: {{{ rule_title }}} - Set /etc/pam.d/ path facts
+  set_fact:
+    {{% if 'ubuntu' in product %}}
+    pam_path: ['/etc/pam.d/common-auth']
+    {{% else %}}
+    pam_path: ['/etc/pam.d/system-auth', '/etc/pam.d/password-auth']
+    {{% endif %}}
+
 - name: {{{ rule_title }}} - Remediation where authselect tool is present
   block:
     {{{ ansible_enable_authselect_feature('with-faillock') | indent(4) }}}
@@ -1016,16 +1024,11 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         insertbefore: ^auth.*sufficient.*pam_unix\.so.*
         {{% endif %}}
         state: present
-      loop:
-        {{% if 'ubuntu' in product %}}
-        - /etc/pam.d/common-auth
-        {{% else %}}
-        - /etc/pam.d/system-auth
-        - /etc/pam.d/password-auth
-        {{% endif %}}
+      loop: '{{ pam_path }}'
       when:
         - result_pam_faillock_is_enabled.found == 0
-    {{% if 'ubuntu' not in product %}}
+
+    {{% if 'ubuntu' in product %}}
     - name: {{{ rule_title }}} - Enable pam_faillock.so authsucc editing PAM files
       ansible.builtin.lineinfile:
         path: /etc/pam.d/common-auth
@@ -1046,13 +1049,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         {{% endif %}}
         insertbefore: ^auth.*required.*pam_deny\.so.*
         state: present
-      loop:
-        {{% if 'ubuntu' in product %}}
-        - /etc/pam.d/common-auth
-        {{% else %}}
-        - /etc/pam.d/system-auth
-        - /etc/pam.d/password-auth
-        {{% endif %}}
+      loop: '{{ pam_path }}'
       when:
         - result_pam_faillock_is_enabled.found == 0
 
@@ -1063,9 +1060,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         line: account     required      pam_faillock.so
         insertbefore: ^account.*required.*pam_unix\.so.*
         state: present
-      loop:
-        - /etc/pam.d/system-auth
-        - /etc/pam.d/password-auth
+      loop: '{{ pam_path }}'
       when:
         - result_pam_faillock_is_enabled.found == 0
     {{% endif %}}
@@ -1092,6 +1087,14 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 {{%- if faillock_var_name != '' %}}
 {{{ ansible_instantiate_variables( faillock_var_name ) }}}
 {{%- endif %}}
+
+- name: {{{ rule_title }}} - Set /etc/pam.d/ path facts
+  set_fact:
+    {{% if 'ubuntu' in product %}}
+    pam_path: ['/etc/pam.d/common-auth']
+    {{% else %}}
+    pam_path: ['/etc/pam.d/system-auth', '/etc/pam.d/password-auth']
+    {{% endif %}}
 
 - name: {{{ rule_title }}} - Check the presence of /etc/security/faillock.conf file
   ansible.builtin.stat:
@@ -1150,13 +1153,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         line: \1required\3 {{{ parameter }}}={{ {{{ faillock_var_name }}} }}
         {{%- endif %}}
         state: present
-      loop:
-        {{% if 'ubuntu' in product %}}
-        - /etc/pam.d/common-auth
-        {{% else %}}
-        - /etc/pam.d/system-auth
-        - /etc/pam.d/password-auth
-        {{% endif %}}
+      loop: '{{ pam_path }}'
       when:
         - result_pam_faillock_{{{ parameter }}}_parameter_is_present.found == 0
 
@@ -1172,13 +1169,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         line: \1required\3 {{{ parameter }}}={{ {{{ faillock_var_name }}} }}
         {{%- endif %}}
         state: present
-      loop:
-        {{% if 'ubuntu' in product %}}
-        - /etc/pam.d/common-auth
-        {{% else %}}
-        - /etc/pam.d/system-auth
-        - /etc/pam.d/password-auth
-        {{% endif %}}
+      loop: '{{ pam_path }}'
       when:
         - result_pam_faillock_{{{ parameter }}}_parameter_is_present.found == 0
     {{%- endif %}}
@@ -1191,13 +1182,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so preauth.*)({{{ parameter }}})=[0-9]+(.*)
         line: \1required\3\4={{ {{{ faillock_var_name }}} }}\5
         state: present
-      loop:
-        {{% if 'ubuntu' in product %}}
-        - /etc/pam.d/common-auth
-        {{% else %}}
-        - /etc/pam.d/system-auth
-        - /etc/pam.d/password-auth
-        {{% endif %}}
+      loop: '{{ pam_path }}'
       when:
         - result_pam_faillock_{{{ parameter }}}_parameter_is_present.found > 0
 
@@ -1209,13 +1194,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so authfail.*)({{{ parameter }}})=[0-9]+(.*)
         line: \1required\3\4={{ {{{ faillock_var_name }}} }}\5
         state: present
-      loop:
-        {{% if 'ubuntu' in product %}}
-        - /etc/pam.d/common-auth
-        {{% else %}}
-        - /etc/pam.d/system-auth
-        - /etc/pam.d/password-auth
-        {{% endif %}}
+      loop: '{{ pam_path }}'
       when:
         - result_pam_faillock_{{{ parameter }}}_parameter_is_present.found > 0
     {{%- endif %}}


### PR DESCRIPTION
This commit will fix oval checks for accounts-pam which includes regex modularization, and proper line remediations for /etc/pam.d/common-auth along with /etc/security/faillock.conf.

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._