### PR TITLE
Fix UBTU-20-010033 OVAL and Ansible

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/oval/shared.xml
@@ -4,6 +4,8 @@
 {{% set smartcard_packages = ['pam_pkcs11', 'mozilla-nss', 'mozilla-nss-tools', 'pcsc-ccid', 'pcsc-lite', 'pcsc-tools', 'opensc'] %}}
 {{% elif product in ["rhel7", "ol7"] %}}
 {{% set smartcard_packages = ['pam_pkcs11'] %}}
+{{% elif product in ["ubuntu2004"] %}}
+{{% set smartcard_packages = ['libpam-pkcs11'] %}}
 {{% else %}}
 {{% set smartcard_packages = ['openssl-pkcs11'] %}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/oval/shared.xml
@@ -21,7 +21,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_pam_pkcs11_cert_policy_crl" version="1">
-    <ind:subexpression operation="pattern match">(^|,\s*)(crl_auto|crl_offline)(\s*,|$)</ind:subexpression>
+    <ind:subexpression operation="pattern match">(^|,\s*)(crl_auto|crl_offline)(\s*,|$|;)</ind:subexpression>
   </ind:textfilecontent54_state>
 
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
@@ -8,39 +8,46 @@
   package_facts:
     manager: auto
 
+- name: Set pam package based on OS
+  set_fact:
+    {{% if 'ubuntu' in product %}}
+    pam_package: libpam-pkcs11
+    {{% else %}}
+    pam_package: pam_pkcs11
+    {{% endif %}}
+
 - name: Check to see if 'pam_pkcs11' module is configured in '/etc/pam.d/common-auth'
   shell: grep -E '^\s*auth\s+\S+\s+pam_pkcs11\.so' /etc/pam.d/common-auth || true
   register: check_pam_pkcs11_module_result
-  when: 
-    {{% if 'sle' in product %}}
-    - '"pam_pkcs11" in ansible_facts.packages'
-    {{% else %}}
-    - '"libpam-pkcs11" in ansible_facts.packages'
-    {{% endif %}}
+  changed_when: false
+  when: 'pam_package in ansible_facts.packages'
 
 - name: Configure 'pam_pkcs11' module in '/etc/pam.d/common-auth'
   lineinfile:
     path: /etc/pam.d/common-auth
+    {{% if 'ubuntu' in product %}}
+    line: 'auth    [success=2 default=ignore] pam_pkcs11.so'
+    {{% else %}}
     line: 'auth sufficient pam_pkcs11.so'
+    {{% endif %}}
     insertafter: '^\s*#'
     state: present
-  when:
-    {{% if 'sle' in product %}}
-    - '"pam_pkcs11" in ansible_facts.packages'
-    {{% else %}}
-    - '"libpam-pkcs11" in ansible_facts.packages'
-    {{% endif %}}
-    - '"pam_pkcs11.so" not in check_pam_pkcs11_module_result.stdout'
+  when: 'pam_package in ansible_facts.packages'
 
+{{% if 'ubuntu' in product %}}
+- name: Ensure 'pam_pkcs11' module has '[success=2 default=ignore]' control flag
+  lineinfile:
+    path: /etc/pam.d/common-auth
+    regexp: '^(\s*auth\s+)\S+(\s+pam_pkcs11\.so.*)'
+    line: '\g<1>[success=2 default=ignore]\g<2>'
+    backrefs: yes
+  when: 'pam_package in ansible_facts.packages'
+{{% else %}}
 - name: Ensure 'pam_pkcs11' module has 'sufficient' control flag
   lineinfile:
     path: /etc/pam.d/common-auth
     regexp: '^(\s*auth\s+)\S+(\s+pam_pkcs11\.so.*)'
     line: '\g<1>sufficient\g<2>'
     backrefs: yes
-  when:
-    {{% if 'sle' in product %}}
-    - '"pam_pkcs11" in ansible_facts.packages'
-    {{% else %}}
-    - '"libpam-pkcs11" in ansible_facts.packages' 
-    {{% endif %}}
+  when: 'pam_package in ansible_facts.packages'
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/oval/shared.xml
@@ -16,7 +16,11 @@
 
   <ind:textfilecontent54_object id="object_smart_card_common_auth" version="1">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+    {{% if 'ubuntu' in product %}}
+    <ind:pattern operation="pattern match" datatype="string">^\s*auth\s+(?:\[success=2 default=ignore\])\s+pam_pkcs11.so(?:\s|$)</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match" datatype="string">^\s*auth\s+(?:sufficient|required)\s+pam_pkcs11.so(?:\s|$)</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
This commit will fix the oval definition and remediation by using the correct parameter, "[success=2 default=ignore]" to place as defined within UBTU-20-010033. Additionally, the OVAL definition has been adjusted to the parameter change.

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._