### PR TITLE
Add remediation and OVAL for UBTU-20-010297

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/ansible/ubuntu2004.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/ansible/ubuntu2004.yml
@@ -1,0 +1,51 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Service facts
+  service_facts:
+
+- name: Check if auditctl rules script being used
+  ansible.builtin.find:
+    paths: '/lib/systemd/system/'
+    patterns: 'auditd.service'
+    contains: '^\s*ExecStartPost\s*=[\s\-]*[\w\/]*auditctl'
+  register: auditd_svc_auditctl_used
+
+- name: Check augenrules rules script being used
+  ansible.builtin.find:
+    paths: '/lib/systemd/system/'
+    patterns: 'auditd.service'
+    contains: '^\s*ExecStartPost\s*=[\s\-]*[\w\/]*augenrules'
+  register: auditd_svc_augen_used
+
+- name: Update kmod in /etc/audit/rules.d/audit.rules
+  lineinfile:
+    path: /etc/audit/rules.d/audit.rules
+    line: '-w /bin/kmod -p x -k modules'
+    create: yes
+  when:
+    - '"auditd.service" in ansible_facts.services'
+    - auditd_svc_augen_used is defined and auditd_svc_augen_used.matched >= 1
+  register: augenrules_audit_rules_kmod_update_result
+
+- name: Update kmod in /etc/audit/audit.rules
+  lineinfile:
+    path: /etc/audit/audit.rules
+    line: '-w /bin/kmod -p x -k modules'
+    create: yes
+  when:
+    - '"auditd.service" in ansible_facts.services'
+    - auditd_svc_auditctl_used is defined and auditd_svc_auditctl_used.matched >= 1
+  register: auditctl_audit_rules_kmod_update_result
+
+- name: Restart auditd.service
+  systemd:
+    name: auditd.service
+    state: restarted
+  when:
+    - (augenrules_audit_rules_kmod_update_result.changed or
+       auditctl_audit_rules_kmod_update_result.changed)
+    - ansible_facts.services["auditd.service"].state == "running"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/bash/ubuntu2004.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/bash/ubuntu2004.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_ubuntu
+
+# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+{{{ bash_fix_audit_watch_rule("auditctl", "/bin/kmod", "x", "modules") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/bin/kmod", "x", "modules") }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/oval/ubuntu2004.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/oval/ubuntu2004.xml
@@ -1,0 +1,40 @@
+<def-group>
+    <definition class="compliance" id="audit_rules_privileged_commands_kmod" version="1">
+      {{{ oval_metadata("Ensure audit rule for all uses of the kmod command is enabled.") }}}
+  
+      <criteria operator="OR">
+  
+        <!-- Test the augenrules case -->
+        <criteria operator="AND">
+          <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+          <criterion comment="audit augenrules kmod" test_ref="test_kmod_augenrules" />
+        </criteria>
+  
+        <!-- Test the auditctl case -->
+        <criteria operator="AND">
+          <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+          <criterion comment="audit auditctl kmod" test_ref="test_kmod_auditctl" />
+        </criteria>
+      </criteria>
+    </definition>
+  
+    <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit augenrules kmod" id="test_kmod_augenrules" version="1">
+      <ind:object object_ref="object_kmod_augenrules" />
+    </ind:textfilecontent54_test>
+    <ind:textfilecontent54_object id="object_kmod_augenrules" version="1">
+      <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+      <ind:pattern operation="pattern match">^[\s]*-w[\s]+/bin/kmod[\s]+-p[\s]+x[\s]+-k[\s]+modules[\s]*$</ind:pattern>
+      <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+    </ind:textfilecontent54_object>
+  
+    <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit auditctl kmod" id="test_kmod_auditctl" version="1">
+      <ind:object object_ref="object_kmod_auditctl" />
+    </ind:textfilecontent54_test>
+    <ind:textfilecontent54_object id="object_kmod_auditctl" version="1">
+      <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+      <ind:pattern operation="pattern match">^[\s]*-w[\s]+/bin/kmod[\s]+-p[\s]+x[\s]+-k[\s]+modules[\s]*$</ind:pattern>
+      <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+    </ind:textfilecontent54_object>
+  
+  </def-group>
+  


### PR DESCRIPTION
This commit will add shell and ansible remediations for kmod. Additionally, adds in OVAL definition.

#### Description:

- Add ansible and bash remediations for ubuntu2004
- Add OVAL definition for ubuntu2004 

#### Rationale:

- Required for proper DISA STIG v1r6 benchmark remediation for `kmod` audit