### PR TITLE
Fix path and add ansible remediation UBTU-20-010298

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/ansible/ubuntu2004.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/ansible/ubuntu2004.yml
@@ -1,0 +1,51 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Service facts
+  service_facts:
+
+- name: Check if auditctl rules script being used
+  ansible.builtin.find:
+    paths: '/lib/systemd/system/'
+    patterns: 'auditd.service'
+    contains: '^\s*ExecStartPost\s*=[\s\-]*[\w\/]*auditctl'
+  register: auditd_svc_auditctl_used
+
+- name: Check augenrules rules script being used
+  ansible.builtin.find:
+    paths: '/lib/systemd/system/'
+    patterns: 'auditd.service'
+    contains: '^\s*ExecStartPost\s*=[\s\-]*[\w\/]*augenrules'
+  register: auditd_svc_augen_used
+
+- name: Update fdisk in /etc/audit/rules.d/audit.rules
+  lineinfile:
+    path: /etc/audit/rules.d/audit.rules
+    line: '-w /usr/sbin/fdisk -p x -k modules'
+    create: yes
+  when:
+    - '"auditd.service" in ansible_facts.services'
+    - auditd_svc_augen_used is defined and auditd_svc_augen_used.matched >= 1
+  register: augenrules_audit_rules_fdisk_update_result
+
+- name: Update fdisk in /etc/audit/audit.rules
+  lineinfile:
+    path: /etc/audit/audit.rules
+    line: '-w /usr/sbin/fdisk -p x -k modules'
+    create: yes
+  when:
+    - '"auditd.service" in ansible_facts.services'
+    - auditd_svc_auditctl_used is defined and auditd_svc_auditctl_used.matched >= 1
+  register: auditctl_audit_rules_fdisk_update_result
+
+- name: Restart auditd.service
+  systemd:
+    name: auditd.service
+    state: restarted
+  when:
+    - (augenrules_audit_rules_fdisk_update_result.changed or
+       auditctl_audit_rules_fdisk_update_result.changed)
+    - ansible_facts.services["auditd.service"].state == "running"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/bash/shared.sh
@@ -1,5 +1,11 @@
 # platform = multi_platform_ubuntu
 
+{{%- if product in ['ubuntu2004'] %}}
+    {{%- set fdisk_path = "/usr/sbin/fdisk" %}}
+{{%- else %}}
+    {{%- set fdisk_path = "/sbin/fdisk" %}}
+{{% endif %}}
+
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-{{{ bash_fix_audit_watch_rule("auditctl", "/sbin/fdisk", "x", "modules") }}}
-{{{ bash_fix_audit_watch_rule("augenrules", "/sbin/fdisk", "x", "modules") }}}
+{{{ bash_fix_audit_watch_rule("auditctl", fdisk_path, "x", "modules") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", fdisk_path, "x", "modules") }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/oval/shared.xml
@@ -1,4 +1,10 @@
 <def-group>
+  {{%- if product in ['ubuntu2004'] %}}
+    {{%- set fdisk_pattern = "^[\s]*-w[\s]+/usr/sbin/fdisk[\s]+-p[\s]+x[\s]+-k[\s]+modules[\s]*$" %}}
+  {{%- else %}}
+    {{%- set fdisk_pattern= "^[\s]*-w[\s]+/sbin/fdisk[\s]+-p[\s]+x[\s]+-k[\s]+modules[\s]*$" %}}
+  {{% endif %}}
+
   <definition class="compliance" id="audit_rules_privileged_commands_fdisk" version="1">
     {{{ oval_metadata("Ensure audit rule for all uses of the fdisk command is enabled.") }}}
 
@@ -23,7 +29,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_fdisk_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/sbin/fdisk[\s]+-p[\s]+x[\s]+-k[\s]+modules[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">{{{ fdisk_pattern }}}</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -32,7 +38,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_fdisk_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/sbin/fdisk[\s]+-p[\s]+x[\s]+-k[\s]+modules[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">{{{ fdisk_pattern }}}</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/rule.yml
@@ -30,7 +30,11 @@ ocil: |-
     following command:
 
     <pre>$ sudo auditctl -l | grep fdisk
+    {{% if product in ['ubuntu2004'] %}}
+    -w /usr/sbin/fdisk -p x -k fdisk
+    {{% else %}}
     -w /sbin/fdisk -p x -k fdisk </pre>
+    {{% endif %}}
 
     If the command does not return a line, or the line is commented out, this
     is a finding.


### PR DESCRIPTION
This commit will fix path from /sbin/fdisk to /usr/sbin/fdisk, and will add ansible remediations for ubuntu2004

#### Description:

- Add ansible remediation for fdisk
- Set proper path to `/usr/sbin/fdisk`
- Simplify regex pattern to setting JINJA2 variable

#### Rationale:

- Simplifies complexity
- Utilizes proper path for DISA STIG Benchmark remediation for ubuntu 2004 v1r6