### PR TITLE
Add proper utmp path for UBTU-20-010278

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/ansible/shared.yml
@@ -4,5 +4,11 @@
 # complexity = low
 # disruption = low
 
-{{{ ansible_audit_augenrules_add_watch_rule(path='/run/utmp', permissions='wa', key='session') }}}
-{{{ ansible_audit_auditctl_add_watch_rule(path='/run/utmp', permissions='wa', key='session') }}}
+{{%- if product in ['ubuntu2004'] %}}
+  {{%- set utmp_path = "/var/run/utmp" %}}
+{{%- else %}}
+  {{%- set utmp_path = "/run/utmp" %}}
+{{% endif %}}
+
+{{{ ansible_audit_augenrules_add_watch_rule(path=utmp_path, permissions='wa', key='session') }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path=utmp_path, permissions='wa', key='session') }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/bash/shared.sh
@@ -1,5 +1,11 @@
 # platform = multi_platform_sle,multi_platform_ubuntu
 
+{{%- if product in ['ubuntu2004'] %}}
+  {{%- set utmp_path = "/var/run/utmp" %}}
+{{%- else %}}
+  {{%- set utmp_path = "/run/utmp" %}}
+{{% endif %}}
+
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-{{{ bash_fix_audit_watch_rule("auditctl", "/run/utmp", "wa", "session") }}}
-{{{ bash_fix_audit_watch_rule("augenrules", "/run/utmp", "wa", "session") }}}
+{{{ bash_fix_audit_watch_rule("auditctl", utmp_path, "wa", "session") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", utmp_path, "wa", "session") }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/rule.yml
@@ -1,3 +1,9 @@
+{{%- if product in ['ubuntu2004'] %}}
+  {{%- set utmp_path = "/var/run/utmp" %}}
+{{%- else %}}
+  {{%- set utmp_path = "/run/utmp" %}}
+{{% endif %}}
+
 documentation_complete: true
 
 prodtype: sle15,ubuntu2004,ubuntu2204
@@ -11,12 +17,12 @@ description: |-
     default), add the following lines to a file with suffix <tt>.rules</tt> in the
     directory <tt>/etc/audit/rules.d</tt> in order to watch for attempted manual
     edits of files involved in storing such process information:
-    <pre>-w /run/utmp -p wa -k session</pre>
+    <pre>-w {{{ utmp_path }}} -p wa -k session</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file in order to watch for attempted manual
     edits of files involved in storing such process information:
-    <pre>-w /run/utmp -p wa -k session</pre>
+    <pre>-w {{{ utmp_path }}} -p wa -k session</pre>
 
 rationale: |-
     Manual editing of these files may indicate nefarious activity, such
@@ -38,12 +44,13 @@ ocil_clause: 'Audit rule is not present'
 
 ocil: |-
     To Check the file is being audited by performing the following command
-    <pre> sudo auditctl -l | grep -w '/run/utmp'</pre>
+    <pre> sudo auditctl -l | grep -w '{{{ utmp_path }}}'</pre>
 
 template:
     name: audit_rules_login_events
     vars:
         path: /run/utmp
+        path@ubuntu2004: /var/run/utmp
     backends:
         ansible: "off"
         bash: "off"


### PR DESCRIPTION
This commit will add in proper utmp path: /var/run/utmp for UBTU-20-010278

#### Description:

- Fixes ubuntu2004 path for utmp which is `/var/run/utmp`

#### Rationale:

- Fixes for proper STIG remediation on v1r6 benchmark

