### PR TITLE
Fix excluded_files and recursive for UBTU-20-010416

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -56,8 +56,10 @@ template:
     name: file_permissions
     vars:
         excluded_files@sle15: ['*[bw]tmp', '*lastlog']
+        excluded_files@ubuntu2004: ['*[bw]tmp', '*lastlog']
         file_regex: '.*'
         filemode: '0640'
         filepath: /var/log/
         recursive@sle12: 'true'
         recursive@sle15: 'true'
+        recursive@ubuntu2004: 'true'


### PR DESCRIPTION
The STIG for UBTU-20-010416 specifies the need to exclude b/wtmp and lastlog files. Additionally, all logs under /var/log should have the intended permissions being at least 0640 or less permissive.

#### Description:

- Extends `0640` permissions or less to all log files in `/var/log`
- Adds exclusions for b/wtmp and lastlog

#### Rationale:

- Proper remediation of UBTU-20-010416 defined within DISA STIG v1r6 benchmark 
