### PR TITLE
Fix gui banner path for UBTU-20-010002 and simplify

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/ubuntu2004.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/ubuntu2004.yml
@@ -1,0 +1,29 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+- name: "Uncomment banner-message-enable for Login Warning Banner"
+  lineinfile:
+    path: /etc/gdm3/greeter.dconf-defaults
+    regexp: ^(#.*)(banner-message-enable=)
+    line: \2
+    backrefs: true
+
+- name: "Set banner-message-enable to true for Login Warning Banner"
+  ini_file:
+    dest: /etc/gdm3/greeter.dconf-defaults
+    section: "org/gnome/login-screen"
+    option: banner-message-enable
+    value: "true"
+    create: yes
+    no_extra_spaces: yes
+
+- name: Dconf Update
+  command: dconf update
+
+- name: Restart gdm3.service
+  systemd:
+    name: gdm3
+    enabled: true
+    state: restarted

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/oval/shared.xml
@@ -1,4 +1,10 @@
 <def-group>
+  {{% if product not in ['ubuntu2004'] %}}
+    {{%- set gui_banner_path = "/etc/dconf/db/{{{ dconf_gdm_dir }}}" %}}
+  {{%- else %}}
+    {{%- set gui_banner_path = "/etc/gdm3/greeter.dconf-defaults" %}}
+  {{% endif %}}
+
   <definition class="compliance" id="dconf_gnome_banner_enabled" version="1">
     {{{ oval_metadata("Enable the GNOME3 Login warning banner.") }}}
     <criteria operator="OR">
@@ -6,7 +12,9 @@
       <criteria comment="Enable GUI banner and prevent user from changing it" operator="AND">
         <extend_definition comment="dconf user profile exists" definition_ref="enable_dconf_user_profile" />
         <criterion comment="Enable GUI banner" test_ref="test_banner_gui_enabled" />
+        {{% if product not in ['ubuntu2004'] %}}
         <criterion comment="Prevent user from disabling banner" test_ref="test_prevent_user_banner_gui_enabled_change" />
+        {{% endif %}}
       </criteria>
     </criteria>
   </definition>
@@ -18,7 +26,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_banner_gui_enabled"
   version="1">
-    <ind:path>/etc/dconf/db/{{{ dconf_gdm_dir }}}/</ind:path>
+    <ind:path>{{{ gui_banner_path }}}</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
     <ind:pattern operation="pattern match">^\[org/gnome/login-screen\]([^\n]*\n+)+?banner-message-enable=true$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
@@ -31,7 +39,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_prevent_user_banner_gui_enabled_change"
   version="1">
-    <ind:path>/etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/</ind:path>
+    <ind:path>{{{ gui_banner_path }}}/locks/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
     <ind:pattern operation="pattern match">^/org/gnome/login-screen/banner-message-enable$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
@@ -10,6 +10,7 @@ description: |-
     screen by setting <tt>banner-message-enable</tt> to <tt>true</tt>.
     <br /><br />
     To enable, add or edit <tt>banner-message-enable</tt> to
+    {{% if product not in ['ubuntu2004'] %}}
     <tt>/etc/dconf/db/{{{ dconf_gdm_dir }}}/00-security-settings</tt>. For example:
     <pre>[org/gnome/login-screen]
     banner-message-enable=true</pre>
@@ -17,6 +18,11 @@ description: |-
     <tt>/etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/00-security-settings-lock</tt> to prevent user modification.
     For example:
     <pre>/org/gnome/login-screen/banner-message-enable</pre>
+    {{% else %}}
+    <tt>/etc/gdm3/greeter.dconf-defaults</tt>. For example:
+    <pre>[org/gnome/login-screen]
+    banner-message-enable=true</pre>
+    {{% endif %}}
     After the settings have been set, run <tt>dconf update</tt>.
     The banner text must also be set.
 
@@ -70,11 +76,16 @@ ocil_clause: 'it is not'
 
 ocil: |-
     To ensure a login warning banner is enabled, run the following:
+    {{% if product not in ['ubuntu2004'] %}}
     <pre>$ grep banner-message-enable /etc/dconf/db/{{{ dconf_gdm_dir }}}/*</pre>
     If properly configured, the output should be <tt>true</tt>.
     To ensure a login warning banner is locked and cannot be changed by a user, run the following:
     <pre>$ grep banner-message-enable /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/login-screen/banner-message-enable</tt>.
+    {{% else %}}
+    <pre>$ grep banner-message-enable /etc/dconf/db/{{{ dconf_gdm_dir }}}/*</pre>
+    If properly configured, the output should be <tt>true</tt>.
+    {{% endif %}}
 
 fixtext: |-
     Configure {{{ full_name }}} to display the Standard Mandatory DoD Notice and Consent Banner before granting access to the system.
@@ -83,9 +94,13 @@ fixtext: |-
 
     Create a database to contain the system-wide graphical user logon settings (if it does not already exist) with the following command:
 
+    {{% if product not in ['ubuntu2004'] %}}
     $ sudo touch /etc/dconf/db/local.d/01-banner-message
 
     Add the following lines to the [org/gnome/login-screen] section of the "/etc/dconf/db/local.d/01-banner-message":
+    {{% else %}}
+    Add the following lines to the [org/gnome/login-screen] section of the "/etc/gdm3/greeter.dconf-defaults":
+    {{% endif %}}
 
     [org/gnome/login-screen]
 


### PR DESCRIPTION
This commit will simplify the path for testing GUI Banner by using gui_banner_path. Additionally, this commit will modify the description for Ubuntu 2004, and add in new ansible remediation

#### Description:

- Fix gui banner path
- Refactor pathing via setting variables to reduce complexity

#### Rationale:

- Enables GUI banner
