### PR TITLE
Add ansible for gnome messsage banner UBTU-20-010003

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/ubuntu.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/ubuntu.yml
@@ -1,0 +1,25 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+{{{ ansible_instantiate_variables("login_banner_text") }}}
+
+- name: "{{{ rule_title }}}"
+  lineinfile:
+    path: /etc/gdm3/greeter.dconf-defaults
+    regexp: ^(#.*)(banner-message-text=)
+    line: \2
+    backrefs: true
+
+- name: "{{{ rule_title }}}"
+  ini_file:
+    dest: /etc/gdm3/greeter.dconf-defaults
+    section: org/gnome/login-screen
+    option: banner-message-text
+    value: '{{{ ansible_deregexify_banner_dconf_gnome("login_banner_text") }}}'
+    create: yes
+    no_extra_spaces: yes
+
+- name: Dconf Update
+  command: dconf update


### PR DESCRIPTION
This commit will add in the ansible remediation for the gnome message banner text for ubuntu.

#### Description:

- Remediate gnome login message banner

#### Rationale:

- Adds ansible remediation for banner text