### PR TITLE
Fix ansible remediation for UBTU-20-010070

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
@@ -12,6 +12,8 @@
 
 {{{ ansible_instantiate_variables("var_password_pam_unix_remember") }}}
 
+{{% if product not in ['ubuntu2004'] %}}
+
 {{{ ansible_pam_pwhistory_enable(accounts_password_pam_unix_remember_file,
                                  'requisite',
                                  '^password.*requisite.*pam_pwquality\.so') }}}
@@ -19,3 +21,11 @@
 {{{ ansible_pam_pwhistory_parameter_value(accounts_password_pam_unix_remember_file,
                                           'remember',
                                           '{{ var_password_pam_unix_remember }}') }}}
+
+{{% else %}}
+{{{ ansible_ensure_pam_module_line(accounts_password_pam_unix_remember_file,
+                                          "password",
+                                          "[success=1 default=ignore]",
+                                          "pam_unix.so obscure sha512 shadow remember=5 rounds=5000")}}}
+
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
@@ -3,6 +3,12 @@
 {{% else %}}
 {{%- set accounts_password_pam_unix_remember_file = '/etc/pam.d/system-auth' -%}}
 {{% endif %}}
+{{% if product in ["ubuntu2004"] %}}
+{{%- set pam_unix_legacy_regex = '^\s*password\s+\[success=1 default=ignore\]\s+pam_unix\.so.*remember=([0-9]*).*$' %}}
+{{% else %}}
+{{%- set pam_unix_legacy_regex = '^\s*password\s+(?:(?:sufficient)|(?:required))\s+pam_unix\.so.*remember=([0-9]*).*$' %}}
+{{% endif %}}
+
 
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="2">
@@ -145,14 +151,14 @@
   <!-- Check the pam_unix.so remember case -->
   <ind:textfilecontent54_test id="test_accounts_password_pam_unix_remember_legacy" version="1"
     check="all" check_existence="all_exist"
-    comment="Test if remember attribute of pam_unix.so is set correctly in /etc/pam.d/system-auth">
+    comment="Test if remember attribute of pam_unix.so is set correctly in {{{ accounts_password_pam_unix_remember_file }}}">
     <ind:object object_ref="object_accounts_password_pam_unix_remember_legacy" />
     <ind:state state_ref="state_accounts_password_pam_unix_remember" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_password_pam_unix_remember_legacy" version="1">
-    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required))\s+pam_unix\.so.*remember=([0-9]*).*$</ind:pattern>
+    <ind:filepath>{{{ accounts_password_pam_unix_remember_file }}}</ind:filepath>
+    <ind:pattern operation="pattern match">{{{ pam_unix_legacy_regex }}}</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>


### PR DESCRIPTION
This commit will fix the ansible remediation by enforcing additional parameters for remembering passwords, specified by UBTU-20-010070.

#### Description:

- Fix the parameters for remembering password

#### Rationale:

- Corrects UBTU-20-010070 to use unix_so with following parameters for enforcing the reuse password guide