### PR TITLE
Add ansible remediation for log perm for UBTU-20-010122

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low
@@ -24,7 +24,7 @@
     log_file: "{{ log_file_line.stdout | trim }}"
   when: (log_file_line.stdout is defined) and (log_file_line.stdout | length > 0)
 
-{{% if 'ol' not in product and "rhel" not in product %}}
+{{% if 'ol' not in product and "rhel" not in product and "ubuntu" not in product %}}
 - name: Get log files group
   command: grep -m 1 ^log_group /etc/audit/auditd.conf
   failed_when: false
@@ -53,7 +53,25 @@
     mode: (( log_group is defined ) and ( ( log_group.stdout | trim ) == 'root' ))  | ternary( '0400', '0440')
   loop: "{{ backup_files.files| map(attribute='path') | list }}"
   failed_when: false
+{{% elif "ubuntu" in product %}}
+- name: List all log file backups
+  find:
+    path: "{{ log_file | dirname }}"
+    patterns: "{{ log_file | basename }}.*"
+  register: backup_files
 
+- name: Apply mode to all backup log files
+  file:
+    path: "{{ item }}"
+    mode: 0600
+  failed_when: false
+  loop: "{{ backup_files.files| map(attribute='path') | list }}"
+
+- name: Apply mode to log file
+  file:
+    path: "{{ log_file }}"
+    mode: 0600
+  failed_when: false
 {{% else %}}
 - name: Apply mode to log file
   file:


### PR DESCRIPTION
This commit will add log perm ansible remediation for ensuring all audit logs are 600 or less permissible.

#### Description:

- Add ansible remediation to ensure audit logs are 0600 or less permissible

#### Rationale:

- Remediates STIG and ensures proper permissions are set
