### PR TITLE
Add ansible remediation for root group owner of audit for UBTU-20-010124

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/ansible/ubuntu.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/ansible/ubuntu.yml
@@ -1,0 +1,44 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Get audit log files
+  command: grep -iw ^log_file /etc/audit/auditd.conf
+  failed_when: false
+  register: log_file_exists
+
+- name: Parse log file line
+  command: awk -F '=' '/^log_file/ {print $2}' /etc/audit/auditd.conf
+  register: log_file_line
+  when: (log_file_exists.stdout | length > 0)
+
+- name: Set default log_file if not set
+  set_fact:
+    log_file: "/var/log/audit/audit.log"
+  when: (log_file_exists is undefined) or (log_file_exists.stdout | length == 0)
+
+- name: Set log_file from log_file_line if not set already
+  set_fact:
+    log_file: "{{ log_file_line.stdout | trim }}"
+  when: (log_file_line.stdout is defined) and (log_file_line.stdout | length > 0)
+
+- name: List all log file backups
+  find:
+    path: "{{ log_file | dirname }}"
+    patterns: "{{ log_file | basename }}.*"
+  register: backup_files
+
+- name: Apply mode to all backup log files
+  file:
+    path: "{{ item }}"
+    group: root
+  failed_when: false
+  loop: "{{ backup_files.files| map(attribute='path') | list }}"
+
+- name: Apply mode to log file
+  file:
+    path: "{{ log_file }}"
+    group: root
+  failed_when: false


### PR DESCRIPTION
#### Description:

- Ensure that all audit logs are group owned by root.

#### Rationale:

- Ansible remediation method for ensuring that audit logs are group owned by root.
