### PR TITLE
Enable ansible remediation for MACs SSH UBTU-20-010043

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,Ubuntu 20.04
 # reboot = false
 # strategy = restrict
 # complexity = low


### PR DESCRIPTION
This commit will enable ansible remediation which will enable MACs SSH config.

#### Description:

- Enable MACs for SSH ansible remediation

#### Rationale:

- Ensures proper MAC ciphers are used for SSH
